### PR TITLE
Improve description

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -41,10 +41,10 @@
 		<meta id="collection-1" property="belongs-to-collection">Monsieur Lecoq</meta>
 		<meta property="collection-type" refines="#collection-1">series</meta>
 		<meta property="group-position" refines="#collection-1">4</meta>
-		<dc:description id="description">A group of blackmailers play a long game on several families; will Lecoq be able to catch them?</dc:description>
+		<dc:description id="description">A group of blackmailers play a long game on several families.</dc:description>
 		<meta id="long-description" property="se:long-description" refines="#description">
-			&lt;p&gt;In this, &lt;a href="https://standardebooks.org/ebooks/emile-gaboriau"&gt;Gaboriau’s&lt;/a&gt; penultimate &lt;a href="https://standardebooks.org/collections/monsieur-lecoq"&gt;Lecoq&lt;/a&gt; novel, Lecoq doesn’t make an appearance until the last few chapters of the book. In fact, it’s not clear who the protagonist(s) is/are until almost halfway through. They’re not missed, though, because the antagonists are a group of blackmailers of exhaustive ingenuity and knowledge, and piecing together the game they’re playing with several noblemen and women occupies all of one’s faculties for most of the book.&lt;/p&gt;
-			&lt;p&gt;Young love, old love, forbidden love, lost love, along with a couple of missing individuals: what is the blackmailer’s endgame? Will Lecoq be able to figure it out in time? Called “French sensational” in its day, Lecoq’s last case is still sensational today.&lt;/p&gt;
+			&lt;p&gt;In this, &lt;a href="https://standardebooks.org/ebooks/emile-gaboriau"&gt;Gaboriau’s&lt;/a&gt; penultimate &lt;a href="https://standardebooks.org/collections/monsieur-lecoq"&gt;Lecoq&lt;/a&gt; novel, Lecoq doesn’t make an appearance until the last few chapters of the book. In fact, the protagonists’ identity remains unclear until almost halfway through. They’re not missed, though, because the antagonists are a group of blackmailers of exhaustive ingenuity and knowledge, and piecing together the game they’re playing with several noblemen and women occupies all of one’s faculties for most of the book.&lt;/p&gt;
+			&lt;p&gt;Young love, old love, forbidden love, lost love, along with a couple of missing individuals: what is the blackmailers’ endgame? Will Lecoq be able to figure it out in time? Called “French sensational” in its day, Lecoq’s last case is still sensational today.&lt;/p&gt;
 		</meta>
 		<dc:language>en-GB</dc:language>
 		<dc:source>https://www.gutenberg.org/ebooks/2451</dc:source>


### PR DESCRIPTION
Original short description:

> A group of blackmailers play a long game on several families; will Lecoq be able to catch them?

Manual says short descriptions must end in a period. I simply removed the second clause:

> A group of blackmailers play a long game on several families.

I considered “Monsieur Lecoq investigates a group of blackmailers playing a long game on several families,” but according to the long description he only shows up in the last few chapters of the book, and the bulk of the story is from the perspective of the blackmailers themselves. (I haven’t read the book yet.)

I also tweaked the long description to remove the awkward “the protagonist(s) is/are” wording. Later in the description the protagonists are already said to be plural.